### PR TITLE
feat: mostrar rango de fechas en las cards de autos del chat

### DIFF
--- a/src/components/layout/ChatFloat.jsx
+++ b/src/components/layout/ChatFloat.jsx
@@ -17,7 +17,7 @@ function normalizeName(name) {
 }
 
 const CAR_BLOCK_SOURCE =
-  /\*\*(SMALL|MEDIUM|LARGE)\s+(.+?)\*\*\n(💰[\s\S]+?)(💵[^\n]+)\n{1,2}(→[^\n]+)/.source;
+  /\*\*(SMALL|MEDIUM|LARGE)\s+(.+?)\*\*\n(?:📅\s*([^\n]+)\n)?(💰[\s\S]+?)(💵[^\n]+)\n{1,2}(→[^\n]+)/.source;
 
 function parseMessage(text, images = []) {
   const re = new RegExp(CAR_BLOCK_SOURCE, 'g');
@@ -32,9 +32,10 @@ function parseMessage(text, images = []) {
       end: match.index + match[0].length,
       type: match[1],
       fullName: match[2],
-      specs: match[3].replace(/\s*\n\s*/g, ' ').trim(),
-      total: match[4],
-      desc: match[5].replace(/^→\s*/, ''),
+      date: match[3] ? match[3].trim() : null,
+      specs: match[4].replace(/\s*\n\s*/g, ' ').trim(),
+      total: match[5],
+      desc: match[6].replace(/^→\s*/, ''),
       image,
     });
   }
@@ -95,6 +96,7 @@ function CarCard({ card }) {
             {card.type}
           </span>
         </div>
+        {card.date && <div className={styles.carDate}>📅 {card.date}</div>}
         <div className={styles.carSpecs}>{card.specs}</div>
         <div className={styles.carTotal}>{card.total}</div>
         <div className={styles.carDesc}>{card.desc}</div>

--- a/src/styles/layout/ChatFloat.module.css
+++ b/src/styles/layout/ChatFloat.module.css
@@ -346,6 +346,13 @@
   flex-shrink: 0;
 }
 
+.carDate {
+  font-size: 12px;
+  font-weight: 600;
+  color: #1B4F72;
+  margin-bottom: 4px;
+}
+
 .carSpecs {
   font-size: 11.5px;
   color: #555;


### PR DESCRIPTION
Cada card ahora muestra una línea con el rango de fechas (cuando el cliente las indica), debajo del nombre del auto. Permite copiar una card individual sin perder el dato de las fechas.